### PR TITLE
Use Router.replace for client-side redirect so back button works

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
  * Export `redirect`
  */
 
+var Router = require('next/router')
+
 module.exports = redirect
 
 /**
@@ -13,6 +15,6 @@ function redirect (ctx, path) {
     ctx.res.writeHead(302, { Location: path })
     ctx.res.end()
   } else {
-    document.location.pathname = path
+    Router.replace(path)
   }
 }


### PR DESCRIPTION
Currently, the client side redirect creates an entry in the browser history, so pressing back always goes to the previous view and redirects again.