### PR TITLE
Allow for redirecting to absolute urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,6 @@ function redirect (ctx, path) {
     ctx.res.writeHead(302, { Location: path })
     ctx.res.end()
   } else {
-    document.location.pathname = path
+    document.location.href = path
   }
 }


### PR DESCRIPTION
Assigning to `.href` allows for both relative and absolute urls.